### PR TITLE
fix: disable link tag from tab index

### DIFF
--- a/packages/react-app/src/components/field-input/text-field-input.tsx
+++ b/packages/react-app/src/components/field-input/text-field-input.tsx
@@ -124,6 +124,7 @@ export default function TextFieldInput({
                 component: 'a',
                 props: {
                   target: '_blank',
+                  tabindex: '-1',
                 },
               },
             },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/691510/162363127-aaf692c7-0838-4c40-8d28-6b59dd7af875.png)

Keyboard-focusable = disabled

Its affect all a tag, link tag.