### PR TITLE
Handle quest versioning

### DIFF
--- a/packages/react-app/src/components/quest.tsx
+++ b/packages/react-app/src/components/quest.tsx
@@ -129,6 +129,7 @@ export default function Quest({
     status: QuestStatus.Draft,
     fallbackAddress: ADDRESS_ZERO,
     creatorAddress: ADDRESS_ZERO,
+    features: {},
   },
   isLoading = false,
   isSummary = false,
@@ -396,7 +397,7 @@ export default function Quest({
                 maxLine={isSummary ? MAX_LINE_DESCRIPTION : undefined}
                 wide
               />
-              {!isSummary && (
+              {!isSummary && questData.features.communicationLink && (
                 <LinkWrapperStyled>
                   <TextFieldInput
                     id="communication-link"

--- a/packages/react-app/src/components/quest.tsx
+++ b/packages/react-app/src/components/quest.tsx
@@ -230,7 +230,7 @@ export default function Quest({
       if (questData.address) {
         let depositReleased = false;
         if (isQuestExpired(questData)) {
-          depositReleased = await QuestService.isCreateQuestDepositReleased(questData.address);
+          depositReleased = await QuestService.isCreateQuestDepositReleased(questData);
         }
         const depositLocked: DepositModel[] = [];
         if (!depositReleased && questData.createDeposit) {
@@ -430,7 +430,7 @@ export default function Quest({
                     {(!isPlayingQuest ||
                       questData.creatorAddress === walletAddress ||
                       (waitForClose && transaction?.type === TransactionType.QuestPlay)) &&
-                      questData.maxPlayers !== undefined && ( // Make sure maxPlayers is set (play feature is available on this quest)
+                      questData.features?.playableQuest && (
                         <PlayModal
                           questData={{ ...questData, players }}
                           onClose={() => setWaitForClose(false)}

--- a/packages/react-app/src/contexts/theme.context.tsx
+++ b/packages/react-app/src/contexts/theme.context.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useMemo } from 'react';
 import { useToggleTheme } from 'src/hooks/use-toggle-theme';
 import { ThemeInterface } from '../styles/theme';
 
@@ -13,12 +13,8 @@ export const useThemeContext = () => useContext(ThemeContext)!;
 type Props = {
   children: React.ReactNode;
 };
-export const ThemeContextProvider = ({ children }: Props) => {
+export function ThemeContextProvider({ children }: Props) {
   const { currentTheme, setCurrentTheme } = useToggleTheme();
-
-  return (
-    <ThemeContext.Provider value={{ currentTheme, setCurrentTheme }}>
-      {children}
-    </ThemeContext.Provider>
-  );
-};
+  const value = useMemo(() => ({ currentTheme, setCurrentTheme }), [currentTheme, setCurrentTheme]);
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}

--- a/packages/react-app/src/contracts/Celeste.json
+++ b/packages/react-app/src/contracts/Celeste.json
@@ -1,523 +1,525 @@
-[
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "uint64", "name": "" }],
-    "name": "getCurrentTermId",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "address", "name": "" }],
-    "name": "getVoting",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "uint64", "name": "" }],
-    "name": "getTermDuration",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "setModules",
-    "inputs": [
-      { "type": "bytes32[]", "name": "_ids" },
-      { "type": "address[]", "name": "_addresses" }
-    ],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "bool", "name": "" }],
-    "name": "areWithdrawalsAllowedFor",
-    "inputs": [{ "type": "address", "name": "_holder" }],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "address", "name": "" }],
-    "name": "getTreasury",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "address", "name": "" }],
-    "name": "getSubscriptions",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "address", "name": "" }],
-    "name": "getFundsGovernor",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [{ "type": "uint64", "name": "" }],
-    "name": "ensureCurrentTerm",
-    "inputs": [],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "address", "name": "" }],
-    "name": "getModulesGovernor",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "uint64", "name": "" }],
-    "name": "getNeededTermTransitions",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "changeFeesUpdater",
-    "inputs": [{ "type": "address", "name": "_newFeesUpdater" }],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "setModule",
-    "inputs": [
-      { "type": "bytes32", "name": "_id" },
-      { "type": "address", "name": "_addr" }
-    ],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "bytes32", "name": "" }],
-    "name": "getTermRandomness",
-    "inputs": [{ "type": "uint64", "name": "_termId" }],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [
-      { "type": "address", "name": "feeToken" },
-      { "type": "uint256", "name": "draftFee" },
-      { "type": "uint16", "name": "penaltyPct" }
-    ],
-    "name": "getDraftConfig",
-    "inputs": [{ "type": "uint64", "name": "_termId" }],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "uint64", "name": "" }],
-    "name": "getConfigChangeTermId",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "address", "name": "" }],
-    "name": "getBrightIdRegister",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [
-      { "type": "address", "name": "recipient" },
-      { "type": "address", "name": "feeToken" },
-      { "type": "uint256", "name": "feeAmount" }
-    ],
-    "name": "getDisputeFees",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "submitEvidence",
-    "inputs": [
-      { "type": "uint256", "name": "_disputeId" },
-      { "type": "address", "name": "_submitter" },
-      { "type": "bytes", "name": "_evidence" }
-    ],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [{ "type": "bytes32", "name": "" }],
-    "name": "ensureCurrentTermRandomness",
-    "inputs": [],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "closeEvidencePeriod",
-    "inputs": [{ "type": "uint256", "name": "_disputeId" }],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "setAutomaticWithdrawals",
-    "inputs": [{ "type": "bool", "name": "_allowed" }],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "uint256", "name": "" }],
-    "name": "getTermTokenTotalSupply",
-    "inputs": [{ "type": "uint64", "name": "_termId" }],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "address", "name": "" }],
-    "name": "getModule",
-    "inputs": [{ "type": "bytes32", "name": "_id" }],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "ejectModulesGovernor",
-    "inputs": [],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "changeFundsGovernor",
-    "inputs": [{ "type": "address", "name": "_newFundsGovernor" }],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "address", "name": "" }],
-    "name": "getJurorsRegistry",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "uint256", "name": "" }],
-    "name": "getMinActiveBalance",
-    "inputs": [{ "type": "uint64", "name": "_termId" }],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "address", "name": "" }],
-    "name": "getConfigGovernor",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [{ "type": "uint64", "name": "" }],
-    "name": "heartbeat",
-    "inputs": [{ "type": "uint64", "name": "_maxRequestedTransitions" }],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "address", "name": "" }],
-    "name": "getFeesUpdater",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "setConfig",
-    "inputs": [
-      { "type": "uint64", "name": "_fromTermId" },
-      { "type": "address", "name": "_feeToken" },
-      { "type": "uint256[3]", "name": "_fees" },
-      { "type": "uint8", "name": "_maxRulingOptions" },
-      { "type": "uint64[9]", "name": "_roundParams" },
-      { "type": "uint16[2]", "name": "_pcts" },
-      { "type": "uint256[2]", "name": "_appealCollateralParams" },
-      { "type": "uint256[3]", "name": "_jurorsParams" }
-    ],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [{ "type": "uint256", "name": "" }],
-    "name": "createDispute",
-    "inputs": [
-      { "type": "uint256", "name": "_possibleRulings" },
-      { "type": "bytes", "name": "_metadata" }
-    ],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "ejectFundsGovernor",
-    "inputs": [],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "changeModulesGovernor",
-    "inputs": [{ "type": "address", "name": "_newModulesGovernor" }],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "changeConfigGovernor",
-    "inputs": [{ "type": "address", "name": "_newConfigGovernor" }],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [
-      { "type": "address", "name": "subject" },
-      { "type": "uint256", "name": "ruling" }
-    ],
-    "name": "rule",
-    "inputs": [{ "type": "uint256", "name": "_disputeId" }],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "address", "name": "" }],
-    "name": "getDisputeManager",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [
-      { "type": "address", "name": "feeToken" },
-      { "type": "uint256[3]", "name": "fees" },
-      { "type": "uint8", "name": "maxRulingOptions" },
-      { "type": "uint64[9]", "name": "roundParams" },
-      { "type": "uint16[2]", "name": "pcts" },
-      { "type": "uint256[2]", "name": "appealCollateralParams" },
-      { "type": "uint256[3]", "name": "jurorsParams" }
-    ],
-    "name": "getConfig",
-    "inputs": [{ "type": "uint64", "name": "_termId" }],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "delayStartTime",
-    "inputs": [{ "type": "uint64", "name": "_newFirstTermStartTime" }],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [
-      { "type": "uint64", "name": "startTime" },
-      { "type": "uint64", "name": "randomnessBN" },
-      { "type": "bytes32", "name": "randomness" },
-      { "type": "uint256", "name": "celesteTokenTotalSupply" }
-    ],
-    "name": "getTerm",
-    "inputs": [{ "type": "uint64", "name": "_termId" }],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "uint64", "name": "" }],
-    "name": "getLastEnsuredTermId",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "constructor",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "inputs": [
-      { "type": "uint64[2]", "name": "_termParams" },
-      { "type": "address[4]", "name": "_governors" },
-      { "type": "address", "name": "_feeToken" },
-      { "type": "uint256[3]", "name": "_fees" },
-      { "type": "uint8", "name": "_maxRulingOptions" },
-      { "type": "uint64[9]", "name": "_roundParams" },
-      { "type": "uint16[2]", "name": "_pcts" },
-      { "type": "uint256[2]", "name": "_appealCollateralParams" },
-      { "type": "uint256[3]", "name": "_jurorsParams" }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "ModuleSet",
-    "inputs": [
-      { "type": "bytes32", "name": "id", "indexed": false },
-      { "type": "address", "name": "addr", "indexed": false }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "FundsGovernorChanged",
-    "inputs": [
-      { "type": "address", "name": "previousGovernor", "indexed": false },
-      { "type": "address", "name": "currentGovernor", "indexed": false }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ConfigGovernorChanged",
-    "inputs": [
-      { "type": "address", "name": "previousGovernor", "indexed": false },
-      { "type": "address", "name": "currentGovernor", "indexed": false }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "FeesUpdaterChanged",
-    "inputs": [
-      { "type": "address", "name": "previousFeesUpdater", "indexed": false },
-      { "type": "address", "name": "currentFeesUpdater", "indexed": false }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ModulesGovernorChanged",
-    "inputs": [
-      { "type": "address", "name": "previousGovernor", "indexed": false },
-      { "type": "address", "name": "currentGovernor", "indexed": false }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "NewConfig",
-    "inputs": [
-      { "type": "uint64", "name": "fromTermId", "indexed": false },
-      { "type": "uint64", "name": "courtConfigId", "indexed": false }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "AutomaticWithdrawalsAllowedChanged",
-    "inputs": [
-      { "type": "address", "name": "holder", "indexed": true },
-      { "type": "bool", "name": "allowed", "indexed": false }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "Heartbeat",
-    "inputs": [
-      { "type": "uint64", "name": "previousTermId", "indexed": false },
-      { "type": "uint64", "name": "currentTermId", "indexed": false }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "StartTimeDelayed",
-    "inputs": [
-      { "type": "uint64", "name": "previousStartTime", "indexed": false },
-      { "type": "uint64", "name": "currentStartTime", "indexed": false }
-    ],
-    "anonymous": false
-  }
-]
+{
+  "abi": [
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "uint64", "name": "" }],
+      "name": "getCurrentTermId",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "address", "name": "" }],
+      "name": "getVoting",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "uint64", "name": "" }],
+      "name": "getTermDuration",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "setModules",
+      "inputs": [
+        { "type": "bytes32[]", "name": "_ids" },
+        { "type": "address[]", "name": "_addresses" }
+      ],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "bool", "name": "" }],
+      "name": "areWithdrawalsAllowedFor",
+      "inputs": [{ "type": "address", "name": "_holder" }],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "address", "name": "" }],
+      "name": "getTreasury",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "address", "name": "" }],
+      "name": "getSubscriptions",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "address", "name": "" }],
+      "name": "getFundsGovernor",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [{ "type": "uint64", "name": "" }],
+      "name": "ensureCurrentTerm",
+      "inputs": [],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "address", "name": "" }],
+      "name": "getModulesGovernor",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "uint64", "name": "" }],
+      "name": "getNeededTermTransitions",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "changeFeesUpdater",
+      "inputs": [{ "type": "address", "name": "_newFeesUpdater" }],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "setModule",
+      "inputs": [
+        { "type": "bytes32", "name": "_id" },
+        { "type": "address", "name": "_addr" }
+      ],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "bytes32", "name": "" }],
+      "name": "getTermRandomness",
+      "inputs": [{ "type": "uint64", "name": "_termId" }],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [
+        { "type": "address", "name": "feeToken" },
+        { "type": "uint256", "name": "draftFee" },
+        { "type": "uint16", "name": "penaltyPct" }
+      ],
+      "name": "getDraftConfig",
+      "inputs": [{ "type": "uint64", "name": "_termId" }],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "uint64", "name": "" }],
+      "name": "getConfigChangeTermId",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "address", "name": "" }],
+      "name": "getBrightIdRegister",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [
+        { "type": "address", "name": "recipient" },
+        { "type": "address", "name": "feeToken" },
+        { "type": "uint256", "name": "feeAmount" }
+      ],
+      "name": "getDisputeFees",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "submitEvidence",
+      "inputs": [
+        { "type": "uint256", "name": "_disputeId" },
+        { "type": "address", "name": "_submitter" },
+        { "type": "bytes", "name": "_evidence" }
+      ],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [{ "type": "bytes32", "name": "" }],
+      "name": "ensureCurrentTermRandomness",
+      "inputs": [],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "closeEvidencePeriod",
+      "inputs": [{ "type": "uint256", "name": "_disputeId" }],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "setAutomaticWithdrawals",
+      "inputs": [{ "type": "bool", "name": "_allowed" }],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "uint256", "name": "" }],
+      "name": "getTermTokenTotalSupply",
+      "inputs": [{ "type": "uint64", "name": "_termId" }],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "address", "name": "" }],
+      "name": "getModule",
+      "inputs": [{ "type": "bytes32", "name": "_id" }],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "ejectModulesGovernor",
+      "inputs": [],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "changeFundsGovernor",
+      "inputs": [{ "type": "address", "name": "_newFundsGovernor" }],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "address", "name": "" }],
+      "name": "getJurorsRegistry",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "uint256", "name": "" }],
+      "name": "getMinActiveBalance",
+      "inputs": [{ "type": "uint64", "name": "_termId" }],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "address", "name": "" }],
+      "name": "getConfigGovernor",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [{ "type": "uint64", "name": "" }],
+      "name": "heartbeat",
+      "inputs": [{ "type": "uint64", "name": "_maxRequestedTransitions" }],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "address", "name": "" }],
+      "name": "getFeesUpdater",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "setConfig",
+      "inputs": [
+        { "type": "uint64", "name": "_fromTermId" },
+        { "type": "address", "name": "_feeToken" },
+        { "type": "uint256[3]", "name": "_fees" },
+        { "type": "uint8", "name": "_maxRulingOptions" },
+        { "type": "uint64[9]", "name": "_roundParams" },
+        { "type": "uint16[2]", "name": "_pcts" },
+        { "type": "uint256[2]", "name": "_appealCollateralParams" },
+        { "type": "uint256[3]", "name": "_jurorsParams" }
+      ],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [{ "type": "uint256", "name": "" }],
+      "name": "createDispute",
+      "inputs": [
+        { "type": "uint256", "name": "_possibleRulings" },
+        { "type": "bytes", "name": "_metadata" }
+      ],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "ejectFundsGovernor",
+      "inputs": [],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "changeModulesGovernor",
+      "inputs": [{ "type": "address", "name": "_newModulesGovernor" }],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "changeConfigGovernor",
+      "inputs": [{ "type": "address", "name": "_newConfigGovernor" }],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [
+        { "type": "address", "name": "subject" },
+        { "type": "uint256", "name": "ruling" }
+      ],
+      "name": "rule",
+      "inputs": [{ "type": "uint256", "name": "_disputeId" }],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "address", "name": "" }],
+      "name": "getDisputeManager",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [
+        { "type": "address", "name": "feeToken" },
+        { "type": "uint256[3]", "name": "fees" },
+        { "type": "uint8", "name": "maxRulingOptions" },
+        { "type": "uint64[9]", "name": "roundParams" },
+        { "type": "uint16[2]", "name": "pcts" },
+        { "type": "uint256[2]", "name": "appealCollateralParams" },
+        { "type": "uint256[3]", "name": "jurorsParams" }
+      ],
+      "name": "getConfig",
+      "inputs": [{ "type": "uint64", "name": "_termId" }],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "delayStartTime",
+      "inputs": [{ "type": "uint64", "name": "_newFirstTermStartTime" }],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [
+        { "type": "uint64", "name": "startTime" },
+        { "type": "uint64", "name": "randomnessBN" },
+        { "type": "bytes32", "name": "randomness" },
+        { "type": "uint256", "name": "celesteTokenTotalSupply" }
+      ],
+      "name": "getTerm",
+      "inputs": [{ "type": "uint64", "name": "_termId" }],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "uint64", "name": "" }],
+      "name": "getLastEnsuredTermId",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "constructor",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "inputs": [
+        { "type": "uint64[2]", "name": "_termParams" },
+        { "type": "address[4]", "name": "_governors" },
+        { "type": "address", "name": "_feeToken" },
+        { "type": "uint256[3]", "name": "_fees" },
+        { "type": "uint8", "name": "_maxRulingOptions" },
+        { "type": "uint64[9]", "name": "_roundParams" },
+        { "type": "uint16[2]", "name": "_pcts" },
+        { "type": "uint256[2]", "name": "_appealCollateralParams" },
+        { "type": "uint256[3]", "name": "_jurorsParams" }
+      ]
+    },
+    {
+      "type": "event",
+      "name": "ModuleSet",
+      "inputs": [
+        { "type": "bytes32", "name": "id", "indexed": false },
+        { "type": "address", "name": "addr", "indexed": false }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "FundsGovernorChanged",
+      "inputs": [
+        { "type": "address", "name": "previousGovernor", "indexed": false },
+        { "type": "address", "name": "currentGovernor", "indexed": false }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ConfigGovernorChanged",
+      "inputs": [
+        { "type": "address", "name": "previousGovernor", "indexed": false },
+        { "type": "address", "name": "currentGovernor", "indexed": false }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "FeesUpdaterChanged",
+      "inputs": [
+        { "type": "address", "name": "previousFeesUpdater", "indexed": false },
+        { "type": "address", "name": "currentFeesUpdater", "indexed": false }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ModulesGovernorChanged",
+      "inputs": [
+        { "type": "address", "name": "previousGovernor", "indexed": false },
+        { "type": "address", "name": "currentGovernor", "indexed": false }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "NewConfig",
+      "inputs": [
+        { "type": "uint64", "name": "fromTermId", "indexed": false },
+        { "type": "uint64", "name": "courtConfigId", "indexed": false }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "AutomaticWithdrawalsAllowedChanged",
+      "inputs": [
+        { "type": "address", "name": "holder", "indexed": true },
+        { "type": "bool", "name": "allowed", "indexed": false }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Heartbeat",
+      "inputs": [
+        { "type": "uint64", "name": "previousTermId", "indexed": false },
+        { "type": "uint64", "name": "currentTermId", "indexed": false }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "StartTimeDelayed",
+      "inputs": [
+        { "type": "uint64", "name": "previousStartTime", "indexed": false },
+        { "type": "uint64", "name": "currentStartTime", "indexed": false }
+      ],
+      "anonymous": false
+    }
+  ]
+}

--- a/packages/react-app/src/contracts/CelesteDisputeManager.json
+++ b/packages/react-app/src/contracts/CelesteDisputeManager.json
@@ -1,442 +1,444 @@
-[
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "setMaxJurorsPerDraftBatch",
-    "inputs": [{ "type": "uint64", "name": "_maxJurorsPerDraftBatch" }],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "ensureCanCommit",
-    "inputs": [
-      { "type": "uint256", "name": "_voteId" },
-      { "type": "address", "name": "_voter" }
-    ],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "createAppeal",
-    "inputs": [
-      { "type": "uint256", "name": "_disputeId" },
-      { "type": "uint256", "name": "_roundId" },
-      { "type": "uint8", "name": "_ruling" }
-    ],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "ensureCanCommit",
-    "inputs": [{ "type": "uint256", "name": "_voteId" }],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [{ "type": "uint256", "name": "" }],
-    "name": "createDispute",
-    "inputs": [
-      { "type": "address", "name": "_subject" },
-      { "type": "uint8", "name": "_possibleRulings" },
-      { "type": "bytes", "name": "_metadata" }
-    ],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "recoverFunds",
-    "inputs": [
-      { "type": "address", "name": "_token" },
-      { "type": "address", "name": "_to" }
-    ],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "address", "name": "" }],
-    "name": "getController",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [{ "type": "uint64", "name": "" }],
-    "name": "maxJurorsPerDraftBatch",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [
-      { "type": "uint64", "name": "draftTerm" },
-      { "type": "uint64", "name": "delayedTerms" },
-      { "type": "uint64", "name": "jurorsNumber" },
-      { "type": "uint64", "name": "selectedJurors" },
-      { "type": "uint256", "name": "jurorFees" },
-      { "type": "bool", "name": "settledPenalties" },
-      { "type": "uint256", "name": "collectedTokens" },
-      { "type": "uint64", "name": "coherentJurors" },
-      { "type": "uint8", "name": "state" }
-    ],
-    "name": "getRound",
-    "inputs": [
-      { "type": "uint256", "name": "_disputeId" },
-      { "type": "uint256", "name": "_roundId" }
-    ],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [
-      { "type": "uint64", "name": "weight" },
-      { "type": "bool", "name": "rewarded" }
-    ],
-    "name": "getJuror",
-    "inputs": [
-      { "type": "uint256", "name": "_disputeId" },
-      { "type": "uint256", "name": "_roundId" },
-      { "type": "address", "name": "_juror" }
-    ],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "submitEvidence",
-    "inputs": [
-      { "type": "address", "name": "_subject" },
-      { "type": "uint256", "name": "_disputeId" },
-      { "type": "address", "name": "_submitter" },
-      { "type": "bytes", "name": "_evidence" }
-    ],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "draft",
-    "inputs": [{ "type": "uint256", "name": "_disputeId" }],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [
-      { "type": "address", "name": "maker" },
-      { "type": "uint64", "name": "appealedRuling" },
-      { "type": "address", "name": "taker" },
-      { "type": "uint64", "name": "opposedRuling" }
-    ],
-    "name": "getAppeal",
-    "inputs": [
-      { "type": "uint256", "name": "_disputeId" },
-      { "type": "uint256", "name": "_roundId" }
-    ],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [
-      { "type": "address", "name": "feeToken" },
-      { "type": "uint256", "name": "totalFees" }
-    ],
-    "name": "getDisputeFees",
-    "inputs": [],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "settleReward",
-    "inputs": [
-      { "type": "uint256", "name": "_disputeId" },
-      { "type": "uint256", "name": "_roundId" },
-      { "type": "address", "name": "_juror" }
-    ],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "settlePenalties",
-    "inputs": [
-      { "type": "uint256", "name": "_disputeId" },
-      { "type": "uint256", "name": "_roundId" },
-      { "type": "uint256", "name": "_jurorsToSettle" }
-    ],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "confirmAppeal",
-    "inputs": [
-      { "type": "uint256", "name": "_disputeId" },
-      { "type": "uint256", "name": "_roundId" },
-      { "type": "uint8", "name": "_ruling" }
-    ],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [
-      { "type": "address", "name": "subject" },
-      { "type": "uint8", "name": "finalRuling" }
-    ],
-    "name": "computeRuling",
-    "inputs": [{ "type": "uint256", "name": "_disputeId" }],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [{ "type": "uint64", "name": "" }],
-    "name": "ensureCanReveal",
-    "inputs": [
-      { "type": "uint256", "name": "_voteId" },
-      { "type": "address", "name": "_voter" }
-    ],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "closeEvidencePeriod",
-    "inputs": [
-      { "type": "address", "name": "_subject" },
-      { "type": "uint256", "name": "_disputeId" }
-    ],
-    "constant": false
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [
-      { "type": "uint64", "name": "nextRoundStartTerm" },
-      { "type": "uint64", "name": "nextRoundJurorsNumber" },
-      { "type": "uint8", "name": "newDisputeState" },
-      { "type": "address", "name": "feeToken" },
-      { "type": "uint256", "name": "totalFees" },
-      { "type": "uint256", "name": "jurorFees" },
-      { "type": "uint256", "name": "appealDeposit" },
-      { "type": "uint256", "name": "confirmAppealDeposit" }
-    ],
-    "name": "getNextRoundDetails",
-    "inputs": [
-      { "type": "uint256", "name": "_disputeId" },
-      { "type": "uint256", "name": "_roundId" }
-    ],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "payable": false,
-    "outputs": [
-      { "type": "address", "name": "subject" },
-      { "type": "uint8", "name": "possibleRulings" },
-      { "type": "uint8", "name": "state" },
-      { "type": "uint8", "name": "finalRuling" },
-      { "type": "uint256", "name": "lastRoundId" },
-      { "type": "uint64", "name": "createTermId" }
-    ],
-    "name": "getDispute",
-    "inputs": [{ "type": "uint256", "name": "_disputeId" }],
-    "constant": true
-  },
-  {
-    "type": "function",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "outputs": [],
-    "name": "settleAppealDeposit",
-    "inputs": [
-      { "type": "uint256", "name": "_disputeId" },
-      { "type": "uint256", "name": "_roundId" }
-    ],
-    "constant": false
-  },
-  {
-    "type": "constructor",
-    "stateMutability": "nonpayable",
-    "payable": false,
-    "inputs": [
-      { "type": "address", "name": "_controller" },
-      { "type": "uint64", "name": "_maxJurorsPerDraftBatch" },
-      { "type": "uint256", "name": "_skippedDisputes" }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "DisputeStateChanged",
-    "inputs": [
-      { "type": "uint256", "name": "disputeId", "indexed": true },
-      { "type": "uint8", "name": "state", "indexed": true }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "EvidenceSubmitted",
-    "inputs": [
-      { "type": "uint256", "name": "disputeId", "indexed": true },
-      { "type": "address", "name": "submitter", "indexed": true },
-      { "type": "bytes", "name": "evidence", "indexed": false }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "EvidencePeriodClosed",
-    "inputs": [
-      { "type": "uint256", "name": "disputeId", "indexed": true },
-      { "type": "uint64", "name": "termId", "indexed": true }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "NewDispute",
-    "inputs": [
-      { "type": "uint256", "name": "disputeId", "indexed": true },
-      { "type": "address", "name": "subject", "indexed": true },
-      { "type": "uint64", "name": "draftTermId", "indexed": true },
-      { "type": "uint64", "name": "jurorsNumber", "indexed": false },
-      { "type": "bytes", "name": "metadata", "indexed": false }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "JurorDrafted",
-    "inputs": [
-      { "type": "uint256", "name": "disputeId", "indexed": true },
-      { "type": "uint256", "name": "roundId", "indexed": true },
-      { "type": "address", "name": "juror", "indexed": true }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "RulingAppealed",
-    "inputs": [
-      { "type": "uint256", "name": "disputeId", "indexed": true },
-      { "type": "uint256", "name": "roundId", "indexed": true },
-      { "type": "uint8", "name": "ruling", "indexed": false }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "RulingAppealConfirmed",
-    "inputs": [
-      { "type": "uint256", "name": "disputeId", "indexed": true },
-      { "type": "uint256", "name": "roundId", "indexed": true },
-      { "type": "uint64", "name": "draftTermId", "indexed": true },
-      { "type": "uint256", "name": "jurorsNumber", "indexed": false }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "RulingComputed",
-    "inputs": [
-      { "type": "uint256", "name": "disputeId", "indexed": true },
-      { "type": "uint8", "name": "ruling", "indexed": true }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "PenaltiesSettled",
-    "inputs": [
-      { "type": "uint256", "name": "disputeId", "indexed": true },
-      { "type": "uint256", "name": "roundId", "indexed": true },
-      { "type": "uint256", "name": "collectedTokens", "indexed": false }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "RewardSettled",
-    "inputs": [
-      { "type": "uint256", "name": "disputeId", "indexed": true },
-      { "type": "uint256", "name": "roundId", "indexed": true },
-      { "type": "address", "name": "juror", "indexed": false },
-      { "type": "uint256", "name": "tokens", "indexed": false },
-      { "type": "uint256", "name": "fees", "indexed": false }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "AppealDepositSettled",
-    "inputs": [
-      { "type": "uint256", "name": "disputeId", "indexed": true },
-      { "type": "uint256", "name": "roundId", "indexed": true }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "MaxJurorsPerDraftBatchChanged",
-    "inputs": [
-      { "type": "uint64", "name": "previousMaxJurorsPerDraftBatch", "indexed": false },
-      { "type": "uint64", "name": "currentMaxJurorsPerDraftBatch", "indexed": false }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "RecoverFunds",
-    "inputs": [
-      { "type": "address", "name": "token", "indexed": false },
-      { "type": "address", "name": "recipient", "indexed": false },
-      { "type": "uint256", "name": "balance", "indexed": false }
-    ],
-    "anonymous": false
-  }
-]
+{
+  "abi": [
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "setMaxJurorsPerDraftBatch",
+      "inputs": [{ "type": "uint64", "name": "_maxJurorsPerDraftBatch" }],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "ensureCanCommit",
+      "inputs": [
+        { "type": "uint256", "name": "_voteId" },
+        { "type": "address", "name": "_voter" }
+      ],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "createAppeal",
+      "inputs": [
+        { "type": "uint256", "name": "_disputeId" },
+        { "type": "uint256", "name": "_roundId" },
+        { "type": "uint8", "name": "_ruling" }
+      ],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "ensureCanCommit",
+      "inputs": [{ "type": "uint256", "name": "_voteId" }],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [{ "type": "uint256", "name": "" }],
+      "name": "createDispute",
+      "inputs": [
+        { "type": "address", "name": "_subject" },
+        { "type": "uint8", "name": "_possibleRulings" },
+        { "type": "bytes", "name": "_metadata" }
+      ],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "recoverFunds",
+      "inputs": [
+        { "type": "address", "name": "_token" },
+        { "type": "address", "name": "_to" }
+      ],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "address", "name": "" }],
+      "name": "getController",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [{ "type": "uint64", "name": "" }],
+      "name": "maxJurorsPerDraftBatch",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [
+        { "type": "uint64", "name": "draftTerm" },
+        { "type": "uint64", "name": "delayedTerms" },
+        { "type": "uint64", "name": "jurorsNumber" },
+        { "type": "uint64", "name": "selectedJurors" },
+        { "type": "uint256", "name": "jurorFees" },
+        { "type": "bool", "name": "settledPenalties" },
+        { "type": "uint256", "name": "collectedTokens" },
+        { "type": "uint64", "name": "coherentJurors" },
+        { "type": "uint8", "name": "state" }
+      ],
+      "name": "getRound",
+      "inputs": [
+        { "type": "uint256", "name": "_disputeId" },
+        { "type": "uint256", "name": "_roundId" }
+      ],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [
+        { "type": "uint64", "name": "weight" },
+        { "type": "bool", "name": "rewarded" }
+      ],
+      "name": "getJuror",
+      "inputs": [
+        { "type": "uint256", "name": "_disputeId" },
+        { "type": "uint256", "name": "_roundId" },
+        { "type": "address", "name": "_juror" }
+      ],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "submitEvidence",
+      "inputs": [
+        { "type": "address", "name": "_subject" },
+        { "type": "uint256", "name": "_disputeId" },
+        { "type": "address", "name": "_submitter" },
+        { "type": "bytes", "name": "_evidence" }
+      ],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "draft",
+      "inputs": [{ "type": "uint256", "name": "_disputeId" }],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [
+        { "type": "address", "name": "maker" },
+        { "type": "uint64", "name": "appealedRuling" },
+        { "type": "address", "name": "taker" },
+        { "type": "uint64", "name": "opposedRuling" }
+      ],
+      "name": "getAppeal",
+      "inputs": [
+        { "type": "uint256", "name": "_disputeId" },
+        { "type": "uint256", "name": "_roundId" }
+      ],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [
+        { "type": "address", "name": "feeToken" },
+        { "type": "uint256", "name": "totalFees" }
+      ],
+      "name": "getDisputeFees",
+      "inputs": [],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "settleReward",
+      "inputs": [
+        { "type": "uint256", "name": "_disputeId" },
+        { "type": "uint256", "name": "_roundId" },
+        { "type": "address", "name": "_juror" }
+      ],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "settlePenalties",
+      "inputs": [
+        { "type": "uint256", "name": "_disputeId" },
+        { "type": "uint256", "name": "_roundId" },
+        { "type": "uint256", "name": "_jurorsToSettle" }
+      ],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "confirmAppeal",
+      "inputs": [
+        { "type": "uint256", "name": "_disputeId" },
+        { "type": "uint256", "name": "_roundId" },
+        { "type": "uint8", "name": "_ruling" }
+      ],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [
+        { "type": "address", "name": "subject" },
+        { "type": "uint8", "name": "finalRuling" }
+      ],
+      "name": "computeRuling",
+      "inputs": [{ "type": "uint256", "name": "_disputeId" }],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [{ "type": "uint64", "name": "" }],
+      "name": "ensureCanReveal",
+      "inputs": [
+        { "type": "uint256", "name": "_voteId" },
+        { "type": "address", "name": "_voter" }
+      ],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "closeEvidencePeriod",
+      "inputs": [
+        { "type": "address", "name": "_subject" },
+        { "type": "uint256", "name": "_disputeId" }
+      ],
+      "constant": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [
+        { "type": "uint64", "name": "nextRoundStartTerm" },
+        { "type": "uint64", "name": "nextRoundJurorsNumber" },
+        { "type": "uint8", "name": "newDisputeState" },
+        { "type": "address", "name": "feeToken" },
+        { "type": "uint256", "name": "totalFees" },
+        { "type": "uint256", "name": "jurorFees" },
+        { "type": "uint256", "name": "appealDeposit" },
+        { "type": "uint256", "name": "confirmAppealDeposit" }
+      ],
+      "name": "getNextRoundDetails",
+      "inputs": [
+        { "type": "uint256", "name": "_disputeId" },
+        { "type": "uint256", "name": "_roundId" }
+      ],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [
+        { "type": "address", "name": "subject" },
+        { "type": "uint8", "name": "possibleRulings" },
+        { "type": "uint8", "name": "state" },
+        { "type": "uint8", "name": "finalRuling" },
+        { "type": "uint256", "name": "lastRoundId" },
+        { "type": "uint64", "name": "createTermId" }
+      ],
+      "name": "getDispute",
+      "inputs": [{ "type": "uint256", "name": "_disputeId" }],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "outputs": [],
+      "name": "settleAppealDeposit",
+      "inputs": [
+        { "type": "uint256", "name": "_disputeId" },
+        { "type": "uint256", "name": "_roundId" }
+      ],
+      "constant": false
+    },
+    {
+      "type": "constructor",
+      "stateMutability": "nonpayable",
+      "payable": false,
+      "inputs": [
+        { "type": "address", "name": "_controller" },
+        { "type": "uint64", "name": "_maxJurorsPerDraftBatch" },
+        { "type": "uint256", "name": "_skippedDisputes" }
+      ]
+    },
+    {
+      "type": "event",
+      "name": "DisputeStateChanged",
+      "inputs": [
+        { "type": "uint256", "name": "disputeId", "indexed": true },
+        { "type": "uint8", "name": "state", "indexed": true }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "EvidenceSubmitted",
+      "inputs": [
+        { "type": "uint256", "name": "disputeId", "indexed": true },
+        { "type": "address", "name": "submitter", "indexed": true },
+        { "type": "bytes", "name": "evidence", "indexed": false }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "EvidencePeriodClosed",
+      "inputs": [
+        { "type": "uint256", "name": "disputeId", "indexed": true },
+        { "type": "uint64", "name": "termId", "indexed": true }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "NewDispute",
+      "inputs": [
+        { "type": "uint256", "name": "disputeId", "indexed": true },
+        { "type": "address", "name": "subject", "indexed": true },
+        { "type": "uint64", "name": "draftTermId", "indexed": true },
+        { "type": "uint64", "name": "jurorsNumber", "indexed": false },
+        { "type": "bytes", "name": "metadata", "indexed": false }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "JurorDrafted",
+      "inputs": [
+        { "type": "uint256", "name": "disputeId", "indexed": true },
+        { "type": "uint256", "name": "roundId", "indexed": true },
+        { "type": "address", "name": "juror", "indexed": true }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RulingAppealed",
+      "inputs": [
+        { "type": "uint256", "name": "disputeId", "indexed": true },
+        { "type": "uint256", "name": "roundId", "indexed": true },
+        { "type": "uint8", "name": "ruling", "indexed": false }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RulingAppealConfirmed",
+      "inputs": [
+        { "type": "uint256", "name": "disputeId", "indexed": true },
+        { "type": "uint256", "name": "roundId", "indexed": true },
+        { "type": "uint64", "name": "draftTermId", "indexed": true },
+        { "type": "uint256", "name": "jurorsNumber", "indexed": false }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RulingComputed",
+      "inputs": [
+        { "type": "uint256", "name": "disputeId", "indexed": true },
+        { "type": "uint8", "name": "ruling", "indexed": true }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PenaltiesSettled",
+      "inputs": [
+        { "type": "uint256", "name": "disputeId", "indexed": true },
+        { "type": "uint256", "name": "roundId", "indexed": true },
+        { "type": "uint256", "name": "collectedTokens", "indexed": false }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RewardSettled",
+      "inputs": [
+        { "type": "uint256", "name": "disputeId", "indexed": true },
+        { "type": "uint256", "name": "roundId", "indexed": true },
+        { "type": "address", "name": "juror", "indexed": false },
+        { "type": "uint256", "name": "tokens", "indexed": false },
+        { "type": "uint256", "name": "fees", "indexed": false }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "AppealDepositSettled",
+      "inputs": [
+        { "type": "uint256", "name": "disputeId", "indexed": true },
+        { "type": "uint256", "name": "roundId", "indexed": true }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MaxJurorsPerDraftBatchChanged",
+      "inputs": [
+        { "type": "uint64", "name": "previousMaxJurorsPerDraftBatch", "indexed": false },
+        { "type": "uint64", "name": "currentMaxJurorsPerDraftBatch", "indexed": false }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RecoverFunds",
+      "inputs": [
+        { "type": "address", "name": "token", "indexed": false },
+        { "type": "address", "name": "recipient", "indexed": false },
+        { "type": "uint256", "name": "balance", "indexed": false }
+      ],
+      "anonymous": false
+    }
+  ]
+}

--- a/packages/react-app/src/contracts/hardhat_contracts.json
+++ b/packages/react-app/src/contracts/hardhat_contracts.json
@@ -4655,283 +4655,444 @@
             }
           ]
         },
-        "Quest": {
-          "address": "0xa6FEAF5CA07b6F367CF39a840F5A7E41d0AE613D",
-          "abi": [
-            {
-              "inputs": [
-                { "internalType": "string", "name": "_questTitle", "type": "string" },
-                {
-                  "internalType": "bytes",
-                  "name": "_questDetailsRef",
-                  "type": "bytes"
-                },
-                {
-                  "internalType": "contract IERC20",
-                  "name": "_rewardToken",
-                  "type": "address"
-                },
-                { "internalType": "uint256", "name": "_expireTime", "type": "uint256" },
-                {
-                  "internalType": "address",
-                  "name": "_aragonGovernAddress",
-                  "type": "address"
-                },
-                {
-                  "internalType": "address payable",
-                  "name": "_fundsRecoveryAddress",
-                  "type": "address"
-                },
-                {
-                  "components": [
-                    {
-                      "internalType": "contract IERC20",
-                      "name": "token",
-                      "type": "address"
-                    },
-                    { "internalType": "uint256", "name": "amount", "type": "uint256" }
-                  ],
-                  "internalType": "struct Models.Deposit",
-                  "name": "_createDeposit",
-                  "type": "tuple"
-                },
-                {
-                  "components": [
-                    {
-                      "internalType": "contract IERC20",
-                      "name": "token",
-                      "type": "address"
-                    },
-                    { "internalType": "uint256", "name": "amount", "type": "uint256" }
-                  ],
-                  "internalType": "struct Models.Deposit",
-                  "name": "_playDeposit",
-                  "type": "tuple"
-                },
-                {
-                  "internalType": "address",
-                  "name": "_questCreator",
-                  "type": "address"
-                },
-                { "internalType": "uint32", "name": "_maxPlayers", "type": "uint32" }
-              ],
-              "stateMutability": "nonpayable",
-              "type": "constructor"
-            },
-            {
-              "anonymous": false,
-              "inputs": [
-                {
-                  "indexed": false,
-                  "internalType": "bytes",
-                  "name": "evidence",
-                  "type": "bytes"
-                },
-                {
-                  "indexed": false,
-                  "internalType": "address",
-                  "name": "player",
-                  "type": "address"
-                },
-                {
-                  "indexed": false,
-                  "internalType": "uint256",
-                  "name": "amount",
-                  "type": "uint256"
-                }
-              ],
-              "name": "QuestClaimed",
-              "type": "event"
-            },
-            {
-              "anonymous": false,
-              "inputs": [
-                {
-                  "indexed": false,
-                  "internalType": "address",
-                  "name": "player",
-                  "type": "address"
-                },
-                {
-                  "indexed": false,
-                  "internalType": "uint256",
-                  "name": "timestamp",
-                  "type": "uint256"
-                }
-              ],
-              "name": "QuestPlayed",
-              "type": "event"
-            },
-            {
-              "anonymous": false,
-              "inputs": [
-                {
-                  "indexed": false,
-                  "internalType": "address",
-                  "name": "player",
-                  "type": "address"
-                },
-                {
-                  "indexed": false,
-                  "internalType": "uint256",
-                  "name": "timestamp",
-                  "type": "uint256"
-                }
-              ],
-              "name": "QuestUnplayed",
-              "type": "event"
-            },
-            {
-              "inputs": [],
-              "name": "aragonGovernAddress",
-              "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [{ "internalType": "address", "name": "executer", "type": "address" }],
-              "name": "canExecute",
-              "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [
-                { "internalType": "bytes", "name": "_evidence", "type": "bytes" },
-                { "internalType": "address", "name": "_player", "type": "address" },
-                { "internalType": "uint256", "name": "_amount", "type": "uint256" },
-                { "internalType": "bool", "name": "_claimAll", "type": "bool" }
-              ],
-              "name": "claim",
-              "outputs": [],
-              "stateMutability": "nonpayable",
-              "type": "function"
-            },
-            {
-              "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-              "name": "claims",
-              "outputs": [
-                { "internalType": "bytes", "name": "evidence", "type": "bytes" },
-                { "internalType": "address", "name": "player", "type": "address" },
-                { "internalType": "uint256", "name": "amount", "type": "uint256" }
-              ],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "createDeposit",
-              "outputs": [
-                {
-                  "internalType": "contract IERC20",
-                  "name": "token",
-                  "type": "address"
-                },
-                { "internalType": "uint256", "name": "amount", "type": "uint256" }
-              ],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "expireTime",
-              "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "fundsRecoveryAddress",
-              "outputs": [{ "internalType": "address payable", "name": "", "type": "address" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "getPlayers",
-              "outputs": [{ "internalType": "address[]", "name": "", "type": "address[]" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "isCreateDepositReleased",
-              "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "maxPlayers",
-              "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [{ "internalType": "address", "name": "_player", "type": "address" }],
-              "name": "play",
-              "outputs": [],
-              "stateMutability": "nonpayable",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "playDeposit",
-              "outputs": [
-                {
-                  "internalType": "contract IERC20",
-                  "name": "token",
-                  "type": "address"
-                },
-                { "internalType": "uint256", "name": "amount", "type": "uint256" }
-              ],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "questCreator",
-              "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "questDetailsRef",
-              "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "questTitle",
-              "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "recoverFundsAndDeposit",
-              "outputs": [],
-              "stateMutability": "nonpayable",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "rewardToken",
-              "outputs": [{ "internalType": "contract IERC20", "name": "", "type": "address" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [{ "internalType": "address", "name": "_player", "type": "address" }],
-              "name": "unplay",
-              "outputs": [],
-              "stateMutability": "nonpayable",
-              "type": "function"
-            }
-          ]
-        },
+        "Quest": [
+          {
+            "abi": [
+              {
+                "type": "constructor",
+                "stateMutability": "nonpayable",
+                "inputs": [
+                  { "type": "string", "name": "_questTitle", "internalType": "string" },
+                  { "type": "bytes", "name": "_questDetailsRef", "internalType": "bytes" },
+                  {
+                    "type": "address",
+                    "name": "_rewardToken",
+                    "internalType": "contract IERC20"
+                  },
+                  { "type": "uint256", "name": "_expireTime", "internalType": "uint256" },
+                  {
+                    "type": "address",
+                    "name": "_aragonGovernAddress",
+                    "internalType": "address"
+                  },
+                  {
+                    "type": "address",
+                    "name": "_fundsRecoveryAddress",
+                    "internalType": "address payable"
+                  },
+                  {
+                    "type": "address",
+                    "name": "_depositToken",
+                    "internalType": "contract IERC20"
+                  },
+                  {
+                    "type": "uint256",
+                    "name": "_depositAmount",
+                    "internalType": "uint256"
+                  },
+                  { "type": "address", "name": "_questCreator", "internalType": "address" }
+                ]
+              },
+              {
+                "type": "event",
+                "name": "QuestClaimed",
+                "inputs": [
+                  {
+                    "type": "bytes",
+                    "name": "evidence",
+                    "internalType": "bytes",
+                    "indexed": false
+                  },
+                  {
+                    "type": "address",
+                    "name": "player",
+                    "internalType": "address",
+                    "indexed": false
+                  },
+                  {
+                    "type": "uint256",
+                    "name": "amount",
+                    "internalType": "uint256",
+                    "indexed": false
+                  }
+                ],
+                "anonymous": false
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [{ "type": "address", "name": "", "internalType": "address" }],
+                "name": "aragonGovernAddress",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "nonpayable",
+                "outputs": [],
+                "name": "claim",
+                "inputs": [
+                  { "type": "bytes", "name": "_evidence", "internalType": "bytes" },
+                  { "type": "address", "name": "_player", "internalType": "address" },
+                  { "type": "uint256", "name": "_amount", "internalType": "uint256" },
+                  { "type": "bool", "name": "_claimAll", "internalType": "bool" }
+                ]
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [
+                  { "type": "bytes", "name": "evidence", "internalType": "bytes" },
+                  { "type": "address", "name": "player", "internalType": "address" },
+                  { "type": "uint256", "name": "amount", "internalType": "uint256" }
+                ],
+                "name": "claims",
+                "inputs": [{ "type": "uint256", "name": "", "internalType": "uint256" }]
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [
+                  { "type": "address", "name": "token", "internalType": "contract IERC20" },
+                  { "type": "uint256", "name": "amount", "internalType": "uint256" }
+                ],
+                "name": "deposit",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [{ "type": "uint256", "name": "", "internalType": "uint256" }],
+                "name": "expireTime",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [{ "type": "address", "name": "", "internalType": "address payable" }],
+                "name": "fundsRecoveryAddress",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [{ "type": "bool", "name": "", "internalType": "bool" }],
+                "name": "isDepositReleased",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [{ "type": "address", "name": "", "internalType": "address" }],
+                "name": "questCreator",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [{ "type": "bytes", "name": "", "internalType": "bytes" }],
+                "name": "questDetailsRef",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [{ "type": "string", "name": "", "internalType": "string" }],
+                "name": "questTitle",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "nonpayable",
+                "outputs": [],
+                "name": "recoverFundsAndDeposit",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [{ "type": "address", "name": "", "internalType": "contract IERC20" }],
+                "name": "rewardToken",
+                "inputs": []
+              }
+            ]
+          },
+          {
+            "abi": [
+              {
+                "inputs": [
+                  { "internalType": "string", "name": "_questTitle", "type": "string" },
+                  {
+                    "internalType": "bytes",
+                    "name": "_questDetailsRef",
+                    "type": "bytes"
+                  },
+                  {
+                    "internalType": "contract IERC20",
+                    "name": "_rewardToken",
+                    "type": "address"
+                  },
+                  { "internalType": "uint256", "name": "_expireTime", "type": "uint256" },
+                  {
+                    "internalType": "address",
+                    "name": "_aragonGovernAddress",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "address payable",
+                    "name": "_fundsRecoveryAddress",
+                    "type": "address"
+                  },
+                  {
+                    "components": [
+                      {
+                        "internalType": "contract IERC20",
+                        "name": "token",
+                        "type": "address"
+                      },
+                      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+                    ],
+                    "internalType": "struct Models.Deposit",
+                    "name": "_createDeposit",
+                    "type": "tuple"
+                  },
+                  {
+                    "components": [
+                      {
+                        "internalType": "contract IERC20",
+                        "name": "token",
+                        "type": "address"
+                      },
+                      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+                    ],
+                    "internalType": "struct Models.Deposit",
+                    "name": "_playDeposit",
+                    "type": "tuple"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "_questCreator",
+                    "type": "address"
+                  },
+                  { "internalType": "uint32", "name": "_maxPlayers", "type": "uint32" }
+                ],
+                "stateMutability": "nonpayable",
+                "type": "constructor"
+              },
+              {
+                "anonymous": false,
+                "inputs": [
+                  {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "evidence",
+                    "type": "bytes"
+                  },
+                  {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "player",
+                    "type": "address"
+                  },
+                  {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                  }
+                ],
+                "name": "QuestClaimed",
+                "type": "event"
+              },
+              {
+                "anonymous": false,
+                "inputs": [
+                  {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "player",
+                    "type": "address"
+                  },
+                  {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "timestamp",
+                    "type": "uint256"
+                  }
+                ],
+                "name": "QuestPlayed",
+                "type": "event"
+              },
+              {
+                "anonymous": false,
+                "inputs": [
+                  {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "player",
+                    "type": "address"
+                  },
+                  {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "timestamp",
+                    "type": "uint256"
+                  }
+                ],
+                "name": "QuestUnplayed",
+                "type": "event"
+              },
+              {
+                "inputs": [],
+                "name": "aragonGovernAddress",
+                "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [{ "internalType": "address", "name": "executer", "type": "address" }],
+                "name": "canExecute",
+                "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [
+                  { "internalType": "bytes", "name": "_evidence", "type": "bytes" },
+                  { "internalType": "address", "name": "_player", "type": "address" },
+                  { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+                  { "internalType": "bool", "name": "_claimAll", "type": "bool" }
+                ],
+                "name": "claim",
+                "outputs": [],
+                "stateMutability": "nonpayable",
+                "type": "function"
+              },
+              {
+                "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+                "name": "claims",
+                "outputs": [
+                  { "internalType": "bytes", "name": "evidence", "type": "bytes" },
+                  { "internalType": "address", "name": "player", "type": "address" },
+                  { "internalType": "uint256", "name": "amount", "type": "uint256" }
+                ],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "createDeposit",
+                "outputs": [
+                  {
+                    "internalType": "contract IERC20",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  { "internalType": "uint256", "name": "amount", "type": "uint256" }
+                ],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "expireTime",
+                "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "fundsRecoveryAddress",
+                "outputs": [{ "internalType": "address payable", "name": "", "type": "address" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "getPlayers",
+                "outputs": [{ "internalType": "address[]", "name": "", "type": "address[]" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "isCreateDepositReleased",
+                "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "maxPlayers",
+                "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [{ "internalType": "address", "name": "_player", "type": "address" }],
+                "name": "play",
+                "outputs": [],
+                "stateMutability": "nonpayable",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "playDeposit",
+                "outputs": [
+                  {
+                    "internalType": "contract IERC20",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  { "internalType": "uint256", "name": "amount", "type": "uint256" }
+                ],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "questCreator",
+                "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "questDetailsRef",
+                "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "questTitle",
+                "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "recoverFundsAndDeposit",
+                "outputs": [],
+                "stateMutability": "nonpayable",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "rewardToken",
+                "outputs": [{ "internalType": "contract IERC20", "name": "", "type": "address" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [{ "internalType": "address", "name": "_player", "type": "address" }],
+                "name": "unplay",
+                "outputs": [],
+                "stateMutability": "nonpayable",
+                "type": "function"
+              }
+            ]
+          }
+        ],
         "QuestFactory": {
           "address": "0xa6FEAF5CA07b6F367CF39a840F5A7E41d0AE613D",
           "abi": [
@@ -9304,283 +9465,444 @@
             ]
           }
         ],
-        "Quest": {
-          "address": "0x2fc3f4A630cD6962A22033436Fd63D93B180c076",
-          "abi": [
-            {
-              "inputs": [
-                { "internalType": "string", "name": "_questTitle", "type": "string" },
-                {
-                  "internalType": "bytes",
-                  "name": "_questDetailsRef",
-                  "type": "bytes"
-                },
-                {
-                  "internalType": "contract IERC20",
-                  "name": "_rewardToken",
-                  "type": "address"
-                },
-                { "internalType": "uint256", "name": "_expireTime", "type": "uint256" },
-                {
-                  "internalType": "address",
-                  "name": "_aragonGovernAddress",
-                  "type": "address"
-                },
-                {
-                  "internalType": "address payable",
-                  "name": "_fundsRecoveryAddress",
-                  "type": "address"
-                },
-                {
-                  "components": [
-                    {
-                      "internalType": "contract IERC20",
-                      "name": "token",
-                      "type": "address"
-                    },
-                    { "internalType": "uint256", "name": "amount", "type": "uint256" }
-                  ],
-                  "internalType": "struct Models.Deposit",
-                  "name": "_createDeposit",
-                  "type": "tuple"
-                },
-                {
-                  "components": [
-                    {
-                      "internalType": "contract IERC20",
-                      "name": "token",
-                      "type": "address"
-                    },
-                    { "internalType": "uint256", "name": "amount", "type": "uint256" }
-                  ],
-                  "internalType": "struct Models.Deposit",
-                  "name": "_playDeposit",
-                  "type": "tuple"
-                },
-                {
-                  "internalType": "address",
-                  "name": "_questCreator",
-                  "type": "address"
-                },
-                { "internalType": "uint32", "name": "_maxPlayers", "type": "uint32" }
-              ],
-              "stateMutability": "nonpayable",
-              "type": "constructor"
-            },
-            {
-              "anonymous": false,
-              "inputs": [
-                {
-                  "indexed": false,
-                  "internalType": "bytes",
-                  "name": "evidence",
-                  "type": "bytes"
-                },
-                {
-                  "indexed": false,
-                  "internalType": "address",
-                  "name": "player",
-                  "type": "address"
-                },
-                {
-                  "indexed": false,
-                  "internalType": "uint256",
-                  "name": "amount",
-                  "type": "uint256"
-                }
-              ],
-              "name": "QuestClaimed",
-              "type": "event"
-            },
-            {
-              "anonymous": false,
-              "inputs": [
-                {
-                  "indexed": false,
-                  "internalType": "address",
-                  "name": "player",
-                  "type": "address"
-                },
-                {
-                  "indexed": false,
-                  "internalType": "uint256",
-                  "name": "timestamp",
-                  "type": "uint256"
-                }
-              ],
-              "name": "QuestPlayed",
-              "type": "event"
-            },
-            {
-              "anonymous": false,
-              "inputs": [
-                {
-                  "indexed": false,
-                  "internalType": "address",
-                  "name": "player",
-                  "type": "address"
-                },
-                {
-                  "indexed": false,
-                  "internalType": "uint256",
-                  "name": "timestamp",
-                  "type": "uint256"
-                }
-              ],
-              "name": "QuestUnplayed",
-              "type": "event"
-            },
-            {
-              "inputs": [],
-              "name": "aragonGovernAddress",
-              "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [{ "internalType": "address", "name": "executer", "type": "address" }],
-              "name": "canExecute",
-              "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [
-                { "internalType": "bytes", "name": "_evidence", "type": "bytes" },
-                { "internalType": "address", "name": "_player", "type": "address" },
-                { "internalType": "uint256", "name": "_amount", "type": "uint256" },
-                { "internalType": "bool", "name": "_claimAll", "type": "bool" }
-              ],
-              "name": "claim",
-              "outputs": [],
-              "stateMutability": "nonpayable",
-              "type": "function"
-            },
-            {
-              "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-              "name": "claims",
-              "outputs": [
-                { "internalType": "bytes", "name": "evidence", "type": "bytes" },
-                { "internalType": "address", "name": "player", "type": "address" },
-                { "internalType": "uint256", "name": "amount", "type": "uint256" }
-              ],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "createDeposit",
-              "outputs": [
-                {
-                  "internalType": "contract IERC20",
-                  "name": "token",
-                  "type": "address"
-                },
-                { "internalType": "uint256", "name": "amount", "type": "uint256" }
-              ],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "expireTime",
-              "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "fundsRecoveryAddress",
-              "outputs": [{ "internalType": "address payable", "name": "", "type": "address" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "getPlayers",
-              "outputs": [{ "internalType": "address[]", "name": "", "type": "address[]" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "isCreateDepositReleased",
-              "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "maxPlayers",
-              "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [{ "internalType": "address", "name": "_player", "type": "address" }],
-              "name": "play",
-              "outputs": [],
-              "stateMutability": "nonpayable",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "playDeposit",
-              "outputs": [
-                {
-                  "internalType": "contract IERC20",
-                  "name": "token",
-                  "type": "address"
-                },
-                { "internalType": "uint256", "name": "amount", "type": "uint256" }
-              ],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "questCreator",
-              "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "questDetailsRef",
-              "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "questTitle",
-              "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "recoverFundsAndDeposit",
-              "outputs": [],
-              "stateMutability": "nonpayable",
-              "type": "function"
-            },
-            {
-              "inputs": [],
-              "name": "rewardToken",
-              "outputs": [{ "internalType": "contract IERC20", "name": "", "type": "address" }],
-              "stateMutability": "view",
-              "type": "function"
-            },
-            {
-              "inputs": [{ "internalType": "address", "name": "_player", "type": "address" }],
-              "name": "unplay",
-              "outputs": [],
-              "stateMutability": "nonpayable",
-              "type": "function"
-            }
-          ]
-        },
+        "Quest": [
+          {
+            "abi": [
+              {
+                "type": "constructor",
+                "stateMutability": "nonpayable",
+                "inputs": [
+                  { "type": "string", "name": "_questTitle", "internalType": "string" },
+                  { "type": "bytes", "name": "_questDetailsRef", "internalType": "bytes" },
+                  {
+                    "type": "address",
+                    "name": "_rewardToken",
+                    "internalType": "contract IERC20"
+                  },
+                  { "type": "uint256", "name": "_expireTime", "internalType": "uint256" },
+                  {
+                    "type": "address",
+                    "name": "_aragonGovernAddress",
+                    "internalType": "address"
+                  },
+                  {
+                    "type": "address",
+                    "name": "_fundsRecoveryAddress",
+                    "internalType": "address payable"
+                  },
+                  {
+                    "type": "address",
+                    "name": "_depositToken",
+                    "internalType": "contract IERC20"
+                  },
+                  {
+                    "type": "uint256",
+                    "name": "_depositAmount",
+                    "internalType": "uint256"
+                  },
+                  { "type": "address", "name": "_questCreator", "internalType": "address" }
+                ]
+              },
+              {
+                "type": "event",
+                "name": "QuestClaimed",
+                "inputs": [
+                  {
+                    "type": "bytes",
+                    "name": "evidence",
+                    "internalType": "bytes",
+                    "indexed": false
+                  },
+                  {
+                    "type": "address",
+                    "name": "player",
+                    "internalType": "address",
+                    "indexed": false
+                  },
+                  {
+                    "type": "uint256",
+                    "name": "amount",
+                    "internalType": "uint256",
+                    "indexed": false
+                  }
+                ],
+                "anonymous": false
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [{ "type": "address", "name": "", "internalType": "address" }],
+                "name": "aragonGovernAddress",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "nonpayable",
+                "outputs": [],
+                "name": "claim",
+                "inputs": [
+                  { "type": "bytes", "name": "_evidence", "internalType": "bytes" },
+                  { "type": "address", "name": "_player", "internalType": "address" },
+                  { "type": "uint256", "name": "_amount", "internalType": "uint256" },
+                  { "type": "bool", "name": "_claimAll", "internalType": "bool" }
+                ]
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [
+                  { "type": "bytes", "name": "evidence", "internalType": "bytes" },
+                  { "type": "address", "name": "player", "internalType": "address" },
+                  { "type": "uint256", "name": "amount", "internalType": "uint256" }
+                ],
+                "name": "claims",
+                "inputs": [{ "type": "uint256", "name": "", "internalType": "uint256" }]
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [
+                  { "type": "address", "name": "token", "internalType": "contract IERC20" },
+                  { "type": "uint256", "name": "amount", "internalType": "uint256" }
+                ],
+                "name": "deposit",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [{ "type": "uint256", "name": "", "internalType": "uint256" }],
+                "name": "expireTime",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [{ "type": "address", "name": "", "internalType": "address payable" }],
+                "name": "fundsRecoveryAddress",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [{ "type": "bool", "name": "", "internalType": "bool" }],
+                "name": "isDepositReleased",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [{ "type": "address", "name": "", "internalType": "address" }],
+                "name": "questCreator",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [{ "type": "bytes", "name": "", "internalType": "bytes" }],
+                "name": "questDetailsRef",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [{ "type": "string", "name": "", "internalType": "string" }],
+                "name": "questTitle",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "nonpayable",
+                "outputs": [],
+                "name": "recoverFundsAndDeposit",
+                "inputs": []
+              },
+              {
+                "type": "function",
+                "stateMutability": "view",
+                "outputs": [{ "type": "address", "name": "", "internalType": "contract IERC20" }],
+                "name": "rewardToken",
+                "inputs": []
+              }
+            ]
+          },
+          {
+            "abi": [
+              {
+                "inputs": [
+                  { "internalType": "string", "name": "_questTitle", "type": "string" },
+                  {
+                    "internalType": "bytes",
+                    "name": "_questDetailsRef",
+                    "type": "bytes"
+                  },
+                  {
+                    "internalType": "contract IERC20",
+                    "name": "_rewardToken",
+                    "type": "address"
+                  },
+                  { "internalType": "uint256", "name": "_expireTime", "type": "uint256" },
+                  {
+                    "internalType": "address",
+                    "name": "_aragonGovernAddress",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "address payable",
+                    "name": "_fundsRecoveryAddress",
+                    "type": "address"
+                  },
+                  {
+                    "components": [
+                      {
+                        "internalType": "contract IERC20",
+                        "name": "token",
+                        "type": "address"
+                      },
+                      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+                    ],
+                    "internalType": "struct Models.Deposit",
+                    "name": "_createDeposit",
+                    "type": "tuple"
+                  },
+                  {
+                    "components": [
+                      {
+                        "internalType": "contract IERC20",
+                        "name": "token",
+                        "type": "address"
+                      },
+                      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+                    ],
+                    "internalType": "struct Models.Deposit",
+                    "name": "_playDeposit",
+                    "type": "tuple"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "_questCreator",
+                    "type": "address"
+                  },
+                  { "internalType": "uint32", "name": "_maxPlayers", "type": "uint32" }
+                ],
+                "stateMutability": "nonpayable",
+                "type": "constructor"
+              },
+              {
+                "anonymous": false,
+                "inputs": [
+                  {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "evidence",
+                    "type": "bytes"
+                  },
+                  {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "player",
+                    "type": "address"
+                  },
+                  {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                  }
+                ],
+                "name": "QuestClaimed",
+                "type": "event"
+              },
+              {
+                "anonymous": false,
+                "inputs": [
+                  {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "player",
+                    "type": "address"
+                  },
+                  {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "timestamp",
+                    "type": "uint256"
+                  }
+                ],
+                "name": "QuestPlayed",
+                "type": "event"
+              },
+              {
+                "anonymous": false,
+                "inputs": [
+                  {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "player",
+                    "type": "address"
+                  },
+                  {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "timestamp",
+                    "type": "uint256"
+                  }
+                ],
+                "name": "QuestUnplayed",
+                "type": "event"
+              },
+              {
+                "inputs": [],
+                "name": "aragonGovernAddress",
+                "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [{ "internalType": "address", "name": "executer", "type": "address" }],
+                "name": "canExecute",
+                "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [
+                  { "internalType": "bytes", "name": "_evidence", "type": "bytes" },
+                  { "internalType": "address", "name": "_player", "type": "address" },
+                  { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+                  { "internalType": "bool", "name": "_claimAll", "type": "bool" }
+                ],
+                "name": "claim",
+                "outputs": [],
+                "stateMutability": "nonpayable",
+                "type": "function"
+              },
+              {
+                "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+                "name": "claims",
+                "outputs": [
+                  { "internalType": "bytes", "name": "evidence", "type": "bytes" },
+                  { "internalType": "address", "name": "player", "type": "address" },
+                  { "internalType": "uint256", "name": "amount", "type": "uint256" }
+                ],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "createDeposit",
+                "outputs": [
+                  {
+                    "internalType": "contract IERC20",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  { "internalType": "uint256", "name": "amount", "type": "uint256" }
+                ],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "expireTime",
+                "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "fundsRecoveryAddress",
+                "outputs": [{ "internalType": "address payable", "name": "", "type": "address" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "getPlayers",
+                "outputs": [{ "internalType": "address[]", "name": "", "type": "address[]" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "isCreateDepositReleased",
+                "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "maxPlayers",
+                "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [{ "internalType": "address", "name": "_player", "type": "address" }],
+                "name": "play",
+                "outputs": [],
+                "stateMutability": "nonpayable",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "playDeposit",
+                "outputs": [
+                  {
+                    "internalType": "contract IERC20",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  { "internalType": "uint256", "name": "amount", "type": "uint256" }
+                ],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "questCreator",
+                "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "questDetailsRef",
+                "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "questTitle",
+                "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "recoverFundsAndDeposit",
+                "outputs": [],
+                "stateMutability": "nonpayable",
+                "type": "function"
+              },
+              {
+                "inputs": [],
+                "name": "rewardToken",
+                "outputs": [{ "internalType": "contract IERC20", "name": "", "type": "address" }],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              {
+                "inputs": [{ "internalType": "address", "name": "_player", "type": "address" }],
+                "name": "unplay",
+                "outputs": [],
+                "stateMutability": "nonpayable",
+                "type": "function"
+              }
+            ]
+          }
+        ],
         "QuestFactory": {
           "address": "0x2fc3f4A630cD6962A22033436Fd63D93B180c076",
           "abi": [

--- a/packages/react-app/src/models/quest.model.ts
+++ b/packages/react-app/src/models/quest.model.ts
@@ -1,4 +1,5 @@
 import { QuestStatus } from 'src/enums/quest-status.enum';
+import { FeatureSupportModel } from 'src/services/feature-support.service';
 import { TokenModel } from './token.model';
 import { TokenAmountModel } from './token-amount.model';
 import { DepositModel } from './deposit-model';
@@ -25,4 +26,9 @@ export type QuestModel = {
   createDeposit?: DepositModel;
   playDeposit?: DepositModel;
   players?: string[];
+  governAddress?: string;
+  version?: number;
+
+  // Feature support
+  features: FeatureSupportModel;
 };

--- a/packages/react-app/src/queries/quests.query.ts
+++ b/packages/react-app/src/queries/quests.query.ts
@@ -11,6 +11,7 @@ const QuestEntityQuery = gql`
   query questEntity($ID: String) {
     questEntity(id: $ID, subgraphError: allow) {
       id
+      version
       questAddress
       questTitle
       questDescription
@@ -58,6 +59,7 @@ const QuestEntitiesQuery = (payload: any) => gql`
       subgraphError: allow
     ) {
       id
+      version
       questAddress
       questTitle
       questDescription
@@ -102,6 +104,7 @@ const QuestEntitiesLight = (payload: any) => gql`
       ${payload.whiteList !== undefined ? 'questAddress_in: $whiteList' : ''}
      }) {
       id
+      version
       questAddress
       questRewardTokenAddress
       questCreateDepositToken

--- a/packages/react-app/src/services/cache.service.ts
+++ b/packages/react-app/src/services/cache.service.ts
@@ -74,7 +74,7 @@ export async function cacheGovernQueueAddressForQuest(
     questData.address,
     async () => {
       // Retrieve governAddress from Quest contract
-      const quest = getQuestContract(questData.address!);
+      const quest = getQuestContract(questData);
       const governAddress = await quest.aragonGovernAddress();
 
       // Fetch who have the exec role for this govern (who being the bound governQueue)

--- a/packages/react-app/src/services/feature-support.service.ts
+++ b/packages/react-app/src/services/feature-support.service.ts
@@ -2,10 +2,14 @@ import { QuestModel } from 'src/models/quest.model';
 
 export type FeatureSupportModel = {
   playableQuest?: boolean;
+  communicationLink?: boolean;
 };
 
 export function loadFeatureSupport(questModel: QuestModel) {
   if (questModel.version != null) {
-    questModel.features = { playableQuest: questModel.version >= 1 };
+    questModel.features = {
+      playableQuest: questModel.version >= 1,
+      communicationLink: typeof questModel.communicationLink === 'string',
+    };
   }
 }

--- a/packages/react-app/src/services/feature-support.service.ts
+++ b/packages/react-app/src/services/feature-support.service.ts
@@ -1,0 +1,11 @@
+import { QuestModel } from 'src/models/quest.model';
+
+export type FeatureSupportModel = {
+  playableQuest?: boolean;
+};
+
+export function loadFeatureSupport(questModel: QuestModel) {
+  if (questModel.version != null) {
+    questModel.features = { playableQuest: questModel.version >= 1 };
+  }
+}

--- a/packages/react-app/src/services/quest.service.ts
+++ b/packages/react-app/src/services/quest.service.ts
@@ -12,7 +12,7 @@ import {
   ContainersLightQuery as ClaimContainersLightQuery,
   GovernQueueEntities,
 } from 'src/queries/govern-queue-entity.query';
-import { BigNumber, Contract, ContractTransaction, ethers } from 'ethers';
+import { BigNumber, ContractTransaction, ethers } from 'ethers';
 import { ConfigModel, ContainerModel, PayloadModel } from 'src/models/govern.model';
 import { ClaimModel } from 'src/models/claim.model';
 import { ChallengeModel } from 'src/models/challenge.model';
@@ -36,7 +36,7 @@ import { PlayModel } from 'src/models/play.model';
 import { QuestModel } from 'src/models/quest.model';
 import { ADDRESS_ZERO, DEFAULT_CLAIM_EXECUTION_DELAY_MS } from '../constants';
 import { Logger } from '../utils/logger';
-import { fromBigNumber, getDefaultProvider, toBigNumber } from '../utils/web3.utils';
+import { fromBigNumber, toBigNumber } from '../utils/web3.utils';
 import {
   getObjectFromIpfs,
   pushObjectToIpfs,
@@ -59,6 +59,7 @@ import {
   cacheFetchTokenPrice,
   cacheGovernQueueAddressForQuest,
 } from './cache.service';
+import { loadFeatureSupport } from './feature-support.service';
 
 let questList: QuestModel[] = [];
 
@@ -69,13 +70,13 @@ async function mapQuest(questEntity: any, claimCountMap: Map<string, number>) {
   if (!questEntity) return undefined;
   try {
     const questAddress = toChecksumAddress(questEntity.questAddress);
-    const quest = {
+    const quest: QuestModel = {
       address: questAddress,
       title: questEntity.questTitle,
       description: questEntity.questDescription || undefined, // if '' -> undefined
       communicationLink: questEntity.questCommunicationLink,
       detailsRefIpfs: toAscii(questEntity.questDetailsRef),
-      rewardToken: await getTokenInfo(questEntity.questRewardTokenAddress),
+      rewardToken: (await getTokenInfo(questEntity.questRewardTokenAddress)) ?? undefined,
       expireTime: new Date(questEntity.questExpireTimeSec * 1000), // sec to Ms
       creationTime: new Date(questEntity.creationTimestamp * 1000), // sec to Ms
       createDeposit: +questEntity.questCreateDepositToken
@@ -98,7 +99,11 @@ async function mapQuest(questEntity: any, claimCountMap: Map<string, number>) {
       status: QuestStatus.Active,
       players: [],
       governAddress: toChecksumAddress(questEntity.questGovernAddress),
-    } as QuestModel;
+      version: questEntity.version,
+      features: {},
+    };
+
+    loadFeatureSupport(quest);
 
     if (!quest.detailsRefIpfs) {
       quest.description = '[No description]';
@@ -108,13 +113,13 @@ async function mapQuest(questEntity: any, claimCountMap: Map<string, number>) {
     }
 
     if (quest?.maxPlayers !== undefined) {
-      quest.players = await getQuestContract(quest.address!).getPlayers();
+      quest.players = await getQuestContract(quest).getPlayers();
     }
 
     return quest;
   } catch (error) {
     Logger.exception(error, `Failed to map quest :\n${JSON.stringify(questEntity)}`);
-    return undefined;
+    throw error;
   }
 }
 
@@ -238,7 +243,7 @@ async function generateScheduleContainer(
   questData: QuestModel,
   extraDelaySec?: number,
 ): Promise<ContainerModel> {
-  const questContract = getQuestContract(claimData.questAddress);
+  const questContract = getQuestContract(questData);
   const governAddress = await questContract.aragonGovernAddress();
   const governQueueResult = await fetchGovernQueue(questData);
   const erc3000Config = governQueueResult.config;
@@ -486,6 +491,7 @@ export async function getDashboardInfo(): Promise<DashboardModel> {
   const { isTestNetwork } = getNetwork();
   const result = await fetchActiveQuestEntitiesLight();
   const quests = result.questEntities as {
+    version: number;
     questAddress: string;
     questRewardTokenAddress: string;
     questCreateDepositToken: string;
@@ -506,7 +512,10 @@ export async function getDashboardInfo(): Promise<DashboardModel> {
 
         // If max player is not null then the quest is playable
         if (quest.questMaxPlayers) {
-          const questPlayers = await getQuestContract(quest.questAddress!).getPlayers();
+          const questPlayers = await getQuestContract({
+            address: quest.questAddress,
+            version: quest.version,
+          }).getPlayers();
           lockedFunds.push({
             amount: BigNumber.from(quest.questPlayDepositAmount).mul(questPlayers.length),
             token: quest.questPlayDepositToken,
@@ -595,7 +604,7 @@ export async function recoverFundsAndDeposit(
   onTx?: onTxCallback,
 ): Promise<ethers.ContractReceipt | null> {
   if (!quest.address) throw new Error('Quest address is not defined when recovering funds');
-  const questContract = getQuestContract(quest.address, walletAddress);
+  const questContract = getQuestContract(quest, walletAddress);
   if (!questContract) return null;
   Logger.debug('Recovering quest unused funds and deposit...', { quest });
   const tx = await questContract.recoverFundsAndDeposit({
@@ -604,30 +613,13 @@ export async function recoverFundsAndDeposit(
   return handleTransaction(tx, onTx);
 }
 
-export async function getQuestRecoveryAddress(questAddress: string): Promise<string | null> {
-  return getQuestContract(questAddress)?.fundsRecoveryAddress() ?? null;
-}
-
-export async function isCreateQuestDepositReleased(questAddress: string): Promise<boolean> {
-  try {
-    const quest = getQuestContract(questAddress);
-    return await quest.isCreateDepositReleased();
-  } catch (error: any) {
-    try {
-      if (error.code === 'CALL_EXCEPTION') {
-        // TODO: Have a cleaner way to handle backward compatibility
-        return await new Contract(
-          questAddress,
-          ['function isDepositReleased() external view'],
-          getDefaultProvider(),
-        ).isDepositReleased();
-      }
-      return false;
-    } catch (error2) {
-      Logger.warn('Failed to get quest deposit status', { questAddress, error, error2 });
-      return false;
-    }
+export async function isCreateQuestDepositReleased(questData: QuestModel): Promise<boolean> {
+  if (!questData.features?.playableQuest) {
+    return true;
   }
+  // If quest is playable then the `isCreateDepositReleased` function exists
+  const quest = getQuestContract(questData);
+  return quest.isCreateDepositReleased();
 }
 
 export async function playQuest(
@@ -637,7 +629,7 @@ export async function playQuest(
   onTx?: onTxCallback,
 ): Promise<ethers.ContractReceipt | null> {
   if (!quest.address) throw new Error('Quest address is not defined when playing a quest');
-  const questContract = getQuestContract(quest.address, walletAddress);
+  const questContract = getQuestContract(quest, walletAddress);
   if (!questContract) return null;
   Logger.debug('Playing quest...', { quest });
   const tx = await questContract.play(data.player || walletAddress, {
@@ -653,7 +645,7 @@ export async function unplayQuest(
   onTx?: onTxCallback,
 ): Promise<ethers.ContractReceipt | null> {
   if (!quest.address) throw new Error('Quest address is not defined when unplaying a quest');
-  const questContract = getQuestContract(quest.address, walletAddress);
+  const questContract = getQuestContract(quest, walletAddress);
   if (!questContract) return null;
   Logger.debug('Unplaying quest...', { quest });
   const tx = await questContract.unplay(data.player || walletAddress, {

--- a/packages/react-app/src/utils/contract.util.ts
+++ b/packages/react-app/src/utils/contract.util.ts
@@ -65,11 +65,13 @@ function getContract(
       }
     }
     const contractAddress: string = contractAddressOverride ?? askedContract.address;
-    const contractAbi = askedContract.abi ?? askedContract;
+
+    const contractAbi = askedContract.abi;
     const provider = getDefaultProvider();
 
     if (!contractAddress) throw new Error(`${contractName} address was not defined`);
-    if (!contractAbi) throw new Error(`${contractName} ABI was not defined`);
+    if (!contractAbi)
+      throw new Error(`${contractName} ABI was not defined, address: ${contractAddress}`);
 
     contract = new Contract(
       contractAddress,

--- a/packages/react-app/src/utils/contract.util.ts
+++ b/packages/react-app/src/utils/contract.util.ts
@@ -41,6 +41,7 @@ function getContract(
   contractName: string,
   contractAddressOverride?: string,
   walletAddress?: string,
+  abiIndex?: number,
 ): Contract {
   try {
     const id = (contractAddressOverride ?? contractName) + (walletAddress ?? '');
@@ -51,15 +52,16 @@ function getContract(
     const network = getNetwork();
     if (!contracts) contracts = getContractsJson(network);
     let askedContract = contracts[contractName];
-    // Is array of contract, not abi
-    if (Array.isArray(askedContract) && askedContract[0].abi) {
-      if (!contractAddressOverride) {
+    if (Array.isArray(askedContract) && askedContract.length) {
+      if (abiIndex) {
         // If no contract address override, use the last one
-        askedContract = askedContract[askedContract.length - 1];
-      } else {
+        askedContract = askedContract[abiIndex];
+      } else if (contractAddressOverride) {
         askedContract = askedContract.find(
           (c) => c.address.toLowerCase() === contractAddressOverride.toLowerCase(),
         );
+      } else {
+        askedContract = askedContract[askedContract.length - 1]; // Use the last one
       }
     }
     const contractAddress: string = contractAddressOverride ?? askedContract.address;
@@ -125,8 +127,11 @@ export async function getTokenInfo(tokenAddress: string) {
   return null;
 }
 
-export function getQuestContract(questAddress: string, walletAddress?: string): Contract {
-  return getContract('Quest', questAddress, walletAddress);
+export function getQuestContract(
+  questData: { address?: string; version?: number },
+  walletAddress?: string,
+): Contract {
+  return getContract('Quest', questData.address, walletAddress, questData.version);
 }
 
 export function getUniswapPairContract(pairAddress: string) {

--- a/packages/react-app/src/utils/contract.util.ts
+++ b/packages/react-app/src/utils/contract.util.ts
@@ -29,7 +29,7 @@ export function getProviderOrSigner(ethersProvider: any, walletAddress?: string)
 function getContractsJson(network?: any) {
   network = network ?? getNetwork();
   return {
-    Celeste, // Only when not rinkeby (hardhat_contracts.json Celeste will override this one only on rinkeby)
+    Celeste, // Only when not goerli (hardhat_contracts.json Celeste will override this one only on goerli)
     ...contractsJson[network.chainId][network.networkId].contracts,
     ERC20,
     UniswapPair,
@@ -149,8 +149,8 @@ export async function getCelesteDisputeManagerContract(celesteAddressOverride?: 
   return getContract('CelesteDisputeManager', disputeManagerAddress);
 }
 
-export function getQuestContractInterface() {
-  return new ethers.utils.Interface(getContractsJson().Quest.abi);
+export function getQuestContractInterface(version?: number) {
+  return new ethers.utils.Interface(getContractsJson().Quest[version ?? 0].abi);
 }
 
 // #endregion

--- a/packages/subgraphs/quest-subgraph/generated/schema.ts
+++ b/packages/subgraphs/quest-subgraph/generated/schema.ts
@@ -16,6 +16,7 @@ export class QuestEntity extends Entity {
     super();
     this.set("id", Value.fromString(id));
 
+    this.set("version", Value.fromI32(0));
     this.set("questAddress", Value.fromString(""));
     this.set("questTitle", Value.fromString(""));
     this.set("questDescription", Value.fromString(""));
@@ -54,6 +55,15 @@ export class QuestEntity extends Entity {
 
   set id(value: string) {
     this.set("id", Value.fromString(value));
+  }
+
+  get version(): i32 {
+    let value = this.get("version");
+    return value!.toI32();
+  }
+
+  set version(value: i32) {
+    this.set("version", Value.fromI32(value));
   }
 
   get questAddress(): string {

--- a/packages/subgraphs/quest-subgraph/src/mappings/quest-factory.2.ts
+++ b/packages/subgraphs/quest-subgraph/src/mappings/quest-factory.2.ts
@@ -2,14 +2,14 @@ import {
   QuestCreated,
   PlayDepositChanged,
   CreateDepositChanged,
-} from '../../generated/QuestFactoryV2/QuestFactory';
+} from "../../generated/QuestFactoryV2/QuestFactory";
 import {
   CreateDepositEntity,
   PlayDepositEntity,
   QuestEntity,
-} from '../../generated/schema';
-import { Bytes, ipfs } from '@graphprotocol/graph-ts';
-import { json } from '@graphprotocol/graph-ts';
+} from "../../generated/schema";
+import { Bytes, ipfs } from "@graphprotocol/graph-ts";
+import { json } from "@graphprotocol/graph-ts";
 
 export function handleCreateDepositChanged(event: CreateDepositChanged): void {
   let depositEntity = new CreateDepositEntity(
@@ -37,6 +37,7 @@ export function handlePlayDepositChanged(event: PlayDepositChanged): void {
 
 export function handleQuestCreated(event: QuestCreated): void {
   let questEntity = new QuestEntity(event.params.questAddress.toHex());
+  questEntity.version = 1;
   questEntity.questAddress = event.params.questAddress.toHexString();
   questEntity.questTitle = event.params.questTitle;
   questEntity.questDetailsRef = event.params.questDetailsRef;
@@ -52,7 +53,7 @@ export function handleQuestCreated(event: QuestCreated): void {
   questEntity.questMaxPlayers = event.params.maxPlayers;
 
   if (!event.params.questDetailsRef) {
-    questEntity.questDescription = '';
+    questEntity.questDescription = "";
   } else {
     // Fetching quest description with IPFS
     let questDataBytes: Bytes | null = null;
@@ -66,23 +67,23 @@ export function handleQuestCreated(event: QuestCreated): void {
       let jsonResult = json.try_fromBytes(questDataBytes);
       if (jsonResult.isOk) {
         let jsonObject = jsonResult.value.toObject();
-        let communicationLink = jsonObject.get('communicationLink');
-        let questDescription = jsonObject.get('description');
+        let communicationLink = jsonObject.get("communicationLink");
+        let questDescription = jsonObject.get("description");
         questEntity.questCommunicationLink = communicationLink
           ? communicationLink.toString()
-          : '';
+          : "";
         questEntity.questDescription = questDescription
           ? questDescription.toString()
-          : '';
+          : "";
       } else {
         let description = questDataBytes.toString();
         questEntity.questDescription = description
           ? description.toString()
-          : '';
+          : "";
       }
     } else {
       // Continue with empty description
-      questEntity.questDescription = '';
+      questEntity.questDescription = "";
     }
   }
 

--- a/packages/subgraphs/quest-subgraph/src/mappings/quest-factory.ts
+++ b/packages/subgraphs/quest-subgraph/src/mappings/quest-factory.ts
@@ -19,6 +19,7 @@ export function handleDepositChanged(event: DepositChanged): void {
 
 export function handleQuestCreated(event: QuestCreated): void {
   let questEntity = new QuestEntity(event.params.questAddress.toHex());
+  questEntity.version = 0;
   questEntity.questAddress = event.params.questAddress.toHexString();
   questEntity.questTitle = event.params.questTitle;
   questEntity.questDetailsRef = event.params.questDetailsRef;

--- a/packages/subgraphs/quest-subgraph/src/schema.graphql
+++ b/packages/subgraphs/quest-subgraph/src/schema.graphql
@@ -17,6 +17,7 @@ type _Schema_
 
 type QuestEntity @entity(immutable: true) {
   id: ID!
+  version: Int!
   questAddress: String!
   questTitle: String!
   questDescription: String!


### PR DESCRIPTION
- The version set is made in the quest subgraph based on the QuerstFactory version
- Right now, there are two versions of QuestFactory:
  - First one is core MVP
  - The second one includes the playable feature
- The UI makes a distinction between version through a service and expose a flag if the feature is enabled in the quest or not
- There is no contracts change for that